### PR TITLE
Added appMinorVersionSupported

### DIFF
--- a/src/main/plugin/iso19139.sdn-csr/schema-ident.xml
+++ b/src/main/plugin/iso19139.sdn-csr/schema-ident.xml
@@ -5,6 +5,7 @@
 	<name>iso19139.sdn-csr</name>
 	<id>6c103cb0-58c2-11e3-949a-0800200c9a66</id>
 	<version>1.0</version>
+	<appMinorVersionSupported>3.0.5</appMinorVersionSupported>
 	<depends>iso19139</depends>
 	<!-- Profile XSD location -->
 	<schemaLocation>http://www.seadatanet.org http://schemas.seadatanet.org/Standards-Software/Metadata-formats/SDN2_CSR_ISO19139_3.0.0.xsd</schemaLocation>


### PR DESCRIPTION
appMinorVersionSupported is mandatory from version 3.4.3.
cvc-complex-type.2.4.a: Invalid content was found starting with element 'depends'. One of '{"http://geonetwork-opensource.org/schemas/schema-ident":appMinorVersionSupported}' is expected. (Element: depends with parent element: schema)